### PR TITLE
Add missing strategy board configuration to GUI

### DIFF
--- a/crates/metis-docs-gui/src/lib/board-config.ts
+++ b/crates/metis-docs-gui/src/lib/board-config.ts
@@ -131,6 +131,39 @@ const adrPhases: PhaseConfig[] = [
   },
 ];
 
+const strategyPhases: PhaseConfig[] = [
+  {
+    key: 'shaping',
+    title: 'Shaping',
+    description: 'Defining the strategic approach',
+    emptyMessage: 'No strategies being shaped',
+  },
+  {
+    key: 'design',
+    title: 'Design',
+    description: 'Designing the strategy details',
+    emptyMessage: 'No strategies in design',
+  },
+  {
+    key: 'ready',
+    title: 'Ready',
+    description: 'Strategy ready for execution',
+    emptyMessage: 'No strategies ready',
+  },
+  {
+    key: 'active',
+    title: 'Active',
+    description: 'Strategy being executed',
+    emptyMessage: 'No active strategies',
+  },
+  {
+    key: 'completed',
+    title: 'Completed',
+    description: 'Strategy outcomes delivered',
+    emptyMessage: 'No completed strategies',
+  },
+];
+
 const specificationPhases: PhaseConfig[] = [
   {
     key: 'discovery',
@@ -193,6 +226,13 @@ export const boardConfigs: BoardConfig[] = [
     description: 'Strategic direction and outcomes',
     phases: visionPhases,
     documentFilter: (doc) => doc.document_type === 'vision',
+  },
+  {
+    id: 'strategy',
+    title: 'Strategy Board',
+    description: 'Coordinated strategic approaches',
+    phases: strategyPhases,
+    documentFilter: (doc) => doc.document_type === 'strategy',
   },
   {
     id: 'initiative',


### PR DESCRIPTION
There is a chance I broke something in my local that was causing this issue, but I do not think so.  So if this is a real current issue, this fixed it for my local instance.

<img width="944" height="610" alt="image" src="https://github.com/user-attachments/assets/792f8eda-dd12-4939-bcb4-1efb16decaba" />

## Summary

- Adds `strategyPhases` array (shaping, design, ready, active, completed) to `board-config.ts`
- Adds strategy `BoardConfig` entry to `boardConfigs` array so `getBoardConfig('strategy')` returns a valid config

## Problem

When `strategies_enabled = true` in the project config, the `KanbanBoard` component correctly adds a "strategy" tab to the available boards. However, `getBoardConfig('strategy')` returns `undefined` because no `BoardConfig` entry exists for strategies in the `boardConfigs` array.

This causes `getDocumentsByPhase()` to bail out early (line 249: `if (!config) return {}`) and the strategy board renders empty — even though strategy documents exist in the database and are returned by the backend API.

## Root Cause

All other document types (vision, initiative, task, adr, backlog) have both phase definitions and board config entries in `board-config.ts`. Strategies were missing both, despite:
- `BoardType` already including `'strategy'`
- Backend correctly querying and returning strategy documents
- `KanbanBoard.vue` correctly adding the strategy tab when enabled

## Test plan

- [x] Create a project with `strategies_enabled = true` in config
- [x] Create a strategy document under a published vision
- [x] Verify the Strategy Board tab appears and displays the strategy in the correct phase column
- [x] Verified locally with a fresh Metis instance and rebuilt Tauri app

🤖 Generated with [Claude Code](https://claude.com/claude-code)