### PR TITLE
fix: scope Ralph state files to session ID

### DIFF
--- a/plugins/metis/commands/cancel-metis-ralph.md
+++ b/plugins/metis/commands/cancel-metis-ralph.md
@@ -1,6 +1,6 @@
 ---
 description: "Cancel active Metis Ralph loop"
-allowed-tools: ["Bash(test -f .claude/metis-ralph-active.yaml:*)", "Bash(rm .claude/metis-ralph-active.yaml)", "Read(.claude/metis-ralph-active.yaml)"]
+allowed-tools: ["Bash(test -f .claude/metis-ralph-active*:*)", "Bash(rm .claude/metis-ralph-active*:*)", "Bash(ls .claude/metis-ralph-active*:*)", "Read(.claude/metis-ralph-active*)"]
 hide-from-slash-command-tool: "true"
 ---
 
@@ -8,16 +8,25 @@ hide-from-slash-command-tool: "true"
 
 To cancel the Metis Ralph loop:
 
-1. Check if `.claude/metis-ralph-active.yaml` exists using Bash: `test -f .claude/metis-ralph-active.yaml && echo "EXISTS" || echo "NOT_FOUND"`
+1. Find the active state file. Check for session-scoped file first, then legacy:
+   ```bash
+   if [ -n "$CLAUDE_SESSION_ID" ] && [ -f ".claude/metis-ralph-active-${CLAUDE_SESSION_ID}.yaml" ]; then
+     echo "FOUND:.claude/metis-ralph-active-${CLAUDE_SESSION_ID}.yaml"
+   elif [ -f ".claude/metis-ralph-active.yaml" ]; then
+     echo "FOUND:.claude/metis-ralph-active.yaml"
+   else
+     echo "NOT_FOUND"
+   fi
+   ```
 
 2. **If NOT_FOUND**: Say "No active Metis Ralph loop found."
 
-3. **If EXISTS**:
-   - Read `.claude/metis-ralph-active.yaml` to get the current state:
+3. **If FOUND**:
+   - Read the state file to get the current state:
      - `iteration:` field for iteration count
      - `mode:` field for loop type (task or decompose)
      - `short_code:` field for the document being worked on
-   - Remove the file using Bash: `rm .claude/metis-ralph-active.yaml`
+   - Remove the file using Bash: `rm <state_file_path>`
    - Report: "Cancelled Metis Ralph loop for [SHORT_CODE] (was at iteration N, mode: MODE)"
 
 Note: Cancelling does NOT revert any Metis document phase transitions. Progress logged to the task document is preserved.

--- a/plugins/metis/hooks/session-start-hook.sh
+++ b/plugins/metis/hooks/session-start-hook.sh
@@ -2,6 +2,15 @@
 # SessionStart hook for Metis projects
 # Detects .metis directory and provides comprehensive project context
 
+# Read hook input from stdin to extract session_id
+HOOK_INPUT=$(cat)
+
+# Export session ID so Bash tool commands can use it for session-scoped state files
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
+if [ -n "$CLAUDE_ENV_FILE" ] && [ -n "$SESSION_ID" ]; then
+    echo "export CLAUDE_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
+fi
+
 # Exit silently if not in a Metis project
 if [ ! -d "$CLAUDE_PROJECT_DIR/.metis" ]; then
     exit 0

--- a/plugins/metis/hooks/stop-hook.sh
+++ b/plugins/metis/hooks/stop-hook.sh
@@ -4,17 +4,31 @@
 # Prevents session exit when a metis-ralph loop is active
 # Feeds the task prompt back to continue the loop
 # Progress is logged to the task document via MCP
+#
+# State files are session-scoped to prevent cross-session interference
+# when multiple Claude instances run in the same project directory.
 
 set -euo pipefail
 
 # Read hook input from stdin
 HOOK_INPUT=$(cat)
 
-# Check if metis-ralph loop is active
-STATE_FILE=".claude/metis-ralph-active.yaml"
+# Extract session_id to find this session's state file
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
 
-if [[ ! -f "$STATE_FILE" ]]; then
-  # No active loop - allow exit
+# Check for session-scoped state file first, fall back to legacy unscoped file
+if [[ -n "$SESSION_ID" ]] && [[ -f ".claude/metis-ralph-active-${SESSION_ID}.yaml" ]]; then
+  STATE_FILE=".claude/metis-ralph-active-${SESSION_ID}.yaml"
+elif [[ -f ".claude/metis-ralph-active.yaml" ]]; then
+  # Legacy unscoped state file — only use if it belongs to this session
+  STATE_FILE=".claude/metis-ralph-active.yaml"
+  OWNER_SESSION=$(grep '^session_id:' "$STATE_FILE" 2>/dev/null | sed 's/session_id: *//' | tr -d '"' || true)
+  if [[ -n "$OWNER_SESSION" ]] && [[ -n "$SESSION_ID" ]] && [[ "$OWNER_SESSION" != "$SESSION_ID" ]]; then
+    # State file belongs to a different session — do not interfere
+    exit 0
+  fi
+else
+  # No active loop for this session - allow exit
   exit 0
 fi
 

--- a/plugins/metis/scripts/setup-metis-decompose.sh
+++ b/plugins/metis/scripts/setup-metis-decompose.sh
@@ -137,11 +137,20 @@ fi
 
 # Create pointer file with loop state
 # Document access goes through MCP - no file path needed
+# State file is session-scoped to prevent cross-session interference
 mkdir -p .claude
 
-cat > .claude/metis-ralph-active.yaml <<EOF
+# Use session-scoped filename if CLAUDE_SESSION_ID is available
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  STATE_FILE=".claude/metis-ralph-active-${CLAUDE_SESSION_ID}.yaml"
+else
+  STATE_FILE=".claude/metis-ralph-active.yaml"
+fi
+
+cat > "$STATE_FILE" <<EOF
 # Metis Ralph Loop State
 # Progress is logged to the initiative document via MCP
+session_id: "${CLAUDE_SESSION_ID:-}"
 short_code: "$SHORT_CODE"
 project_path: "$PROJECT_PATH"
 mode: decompose

--- a/plugins/metis/scripts/setup-metis-ralph-initiative.sh
+++ b/plugins/metis/scripts/setup-metis-ralph-initiative.sh
@@ -136,11 +136,20 @@ if [[ ! -d "$PROJECT_PATH" ]]; then
 fi
 
 # Create pointer file with loop state
+# State file is session-scoped to prevent cross-session interference
 mkdir -p .claude
 
-cat > .claude/metis-ralph-active.yaml <<EOF
+# Use session-scoped filename if CLAUDE_SESSION_ID is available
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  STATE_FILE=".claude/metis-ralph-active-${CLAUDE_SESSION_ID}.yaml"
+else
+  STATE_FILE=".claude/metis-ralph-active.yaml"
+fi
+
+cat > "$STATE_FILE" <<EOF
 # Metis Ralph Loop State - Initiative Execution Mode
 # Working through all tasks under an initiative
+session_id: "${CLAUDE_SESSION_ID:-}"
 short_code: "$SHORT_CODE"
 project_path: "$PROJECT_PATH"
 mode: initiative

--- a/plugins/metis/scripts/setup-metis-ralph.sh
+++ b/plugins/metis/scripts/setup-metis-ralph.sh
@@ -133,11 +133,20 @@ fi
 
 # Create pointer file with loop state
 # Document access goes through MCP - no file path needed
+# State file is session-scoped to prevent cross-session interference
 mkdir -p .claude
 
-cat > .claude/metis-ralph-active.yaml <<EOF
+# Use session-scoped filename if CLAUDE_SESSION_ID is available
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  STATE_FILE=".claude/metis-ralph-active-${CLAUDE_SESSION_ID}.yaml"
+else
+  STATE_FILE=".claude/metis-ralph-active.yaml"
+fi
+
+cat > "$STATE_FILE" <<EOF
 # Metis Ralph Loop State
 # Progress is logged to the task document via MCP
+session_id: "${CLAUDE_SESSION_ID:-}"
 short_code: "$SHORT_CODE"
 project_path: "$PROJECT_PATH"
 mode: task


### PR DESCRIPTION
## Summary

- Ralph loop state files (`.claude/metis-ralph-active.yaml`) are now scoped per session using `CLAUDE_SESSION_ID`
- Fixes cross-session interference when multiple Claude instances run in the same project directory
- Backwards-compatible: falls back to legacy unscoped filename when session ID is unavailable

## Problem

When multiple Claude sessions operate in the same project, a single shared state file causes:
1. **Stop hook hijacking**: Session B's subagent finds Session A's state file and gets blocked/redirected
2. **State file deletion**: Either session can delete the other's state, silently killing the loop
3. **Race conditions**: Concurrent iteration counter updates can corrupt state

## Changes

| File | Change |
|------|--------|
| `hooks/session-start-hook.sh` | Export `CLAUDE_SESSION_ID` via `CLAUDE_ENV_FILE` |
| `hooks/stop-hook.sh` | Look up state file by session ID; ignore files owned by other sessions |
| `scripts/setup-metis-ralph.sh` | Write session-scoped state filename |
| `scripts/setup-metis-ralph-initiative.sh` | Write session-scoped state filename |
| `scripts/setup-metis-decompose.sh` | Write session-scoped state filename |
| `commands/cancel-metis-ralph.md` | Find session-scoped state file with legacy fallback |

## Test plan

- [ ] Start Ralph loop in Session A, verify state file is named `metis-ralph-active-{SESSION_ID}.yaml`
- [ ] Start Session B in same project, verify its subagents can stop without being blocked
- [ ] Verify Session A's Ralph loop continues unaffected
- [ ] Cancel Ralph loop — verify session-scoped file is removed
- [ ] Test backwards compatibility: remove `CLAUDE_SESSION_ID` env var, verify legacy filename works

🤖 Generated with [Claude Code](https://claude.com/claude-code)