### PR TITLE
fix(metis-docs-core): stop duplicating the acceptance criteria header on save

### DIFF
--- a/crates/metis-docs-core/src/domain/documents/adr/mod.rs
+++ b/crates/metis-docs-core/src/domain/documents/adr/mod.rs
@@ -302,22 +302,11 @@ impl Adr {
             DocumentValidationError::InvalidContent(format!("Frontmatter render error: {}", e))
         })?;
 
-        // Use the actual content body
-        let content_body = &self.content().body;
-
-        // Use actual acceptance criteria if present, otherwise empty string
-        let acceptance_criteria = if let Some(ac) = &self.content().acceptance_criteria {
-            format!("\n\n## Acceptance Criteria\n\n{}", ac)
-        } else {
-            String::new()
-        };
-
         // Combine everything
         Ok(format!(
-            "---\n{}\n---\n\n{}{}",
+            "---\n{}\n---\n\n{}",
             frontmatter.trim_end(),
-            content_body,
-            acceptance_criteria
+            self.content().full_content()
         ))
     }
 }

--- a/crates/metis-docs-core/src/domain/documents/content.rs
+++ b/crates/metis-docs-core/src/domain/documents/content.rs
@@ -26,12 +26,18 @@ impl DocumentContent {
         }
     }
 
+    /// Header that introduces the acceptance criteria section. Stored separately from
+    /// `acceptance_criteria` so round-tripping through `from_markdown`/`full_content`
+    /// never duplicates it.
+    const ACCEPTANCE_CRITERIA_HEADER: &'static str = "## Acceptance Criteria";
+
     /// Parse content from markdown, separating main content from acceptance criteria
     pub fn from_markdown(content: &str) -> Self {
         // Look for "## Acceptance Criteria" section
-        if let Some(criteria_pos) = content.find("## Acceptance Criteria") {
-            let body = content[..criteria_pos].trim().to_string();
-            let acceptance_criteria = content[criteria_pos..].trim().to_string();
+        if let Some(header_pos) = content.find(Self::ACCEPTANCE_CRITERIA_HEADER) {
+            let body = content[..header_pos].trim().to_string();
+            let after_header = &content[header_pos + Self::ACCEPTANCE_CRITERIA_HEADER.len()..];
+            let acceptance_criteria = after_header.trim().to_string();
             Self {
                 body,
                 acceptance_criteria: Some(acceptance_criteria),
@@ -41,10 +47,15 @@ impl DocumentContent {
         }
     }
 
-    /// Get the full content including acceptance criteria
+    /// Get the full content including acceptance criteria, with the header rendered exactly once
     pub fn full_content(&self) -> String {
         match &self.acceptance_criteria {
-            Some(criteria) => format!("{}\n\n{}", self.body, criteria),
+            Some(criteria) => format!(
+                "{}\n\n{}\n\n{}",
+                self.body,
+                Self::ACCEPTANCE_CRITERIA_HEADER,
+                criteria
+            ),
             None => self.body.clone(),
         }
     }
@@ -52,5 +63,27 @@ impl DocumentContent {
     /// Check if acceptance criteria are present
     pub fn has_acceptance_criteria(&self) -> bool {
         self.acceptance_criteria.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_markdown_and_full_content_round_trip_without_duplicating_header() {
+        let markdown = "# Title\n\nBody text\n\n## Acceptance Criteria\n\n- [ ] one\n- [ ] two";
+
+        let content = DocumentContent::from_markdown(markdown);
+        assert_eq!(content.full_content(), markdown);
+        assert_eq!(
+            content.full_content().matches("## Acceptance Criteria").count(),
+            1
+        );
+
+        // Serializing content that was itself parsed from markdown (e.g. an edit-then-save
+        // cycle) must stay stable and never re-introduce the header a second time.
+        let reparsed = DocumentContent::from_markdown(&content.full_content());
+        assert_eq!(reparsed.full_content(), content.full_content());
     }
 }

--- a/crates/metis-docs-core/src/domain/documents/initiative/mod.rs
+++ b/crates/metis-docs-core/src/domain/documents/initiative/mod.rs
@@ -338,22 +338,11 @@ impl Initiative {
             DocumentValidationError::InvalidContent(format!("Frontmatter render error: {}", e))
         })?;
 
-        // Use the actual content body
-        let content_body = &self.content().body;
-
-        // Use actual acceptance criteria if present, otherwise empty string
-        let acceptance_criteria = if let Some(ac) = &self.content().acceptance_criteria {
-            format!("\n\n## Acceptance Criteria\n\n{}", ac)
-        } else {
-            String::new()
-        };
-
         // Combine everything
         Ok(format!(
-            "---\n{}\n---\n\n{}{}",
+            "---\n{}\n---\n\n{}",
             frontmatter.trim_end(),
-            content_body,
-            acceptance_criteria
+            self.content().full_content()
         ))
     }
 }

--- a/crates/metis-docs-core/src/domain/documents/specification/mod.rs
+++ b/crates/metis-docs-core/src/domain/documents/specification/mod.rs
@@ -236,21 +236,10 @@ impl Specification {
             DocumentValidationError::InvalidContent(format!("Frontmatter render error: {}", e))
         })?;
 
-        // Use the actual content body
-        let content_body = &self.content().body;
-
-        // Use actual acceptance criteria if present
-        let acceptance_criteria = if let Some(ac) = &self.content().acceptance_criteria {
-            format!("\n\n## Acceptance Criteria\n\n{}", ac)
-        } else {
-            String::new()
-        };
-
         Ok(format!(
-            "---\n{}\n---\n\n{}{}",
+            "---\n{}\n---\n\n{}",
             frontmatter.trim_end(),
-            content_body,
-            acceptance_criteria
+            self.content().full_content()
         ))
     }
 }

--- a/crates/metis-docs-core/src/domain/documents/task/mod.rs
+++ b/crates/metis-docs-core/src/domain/documents/task/mod.rs
@@ -289,22 +289,11 @@ impl Task {
             DocumentValidationError::InvalidContent(format!("Frontmatter render error: {}", e))
         })?;
 
-        // Use the actual content body
-        let content_body = &self.content().body;
-
-        // Use actual acceptance criteria if present, otherwise empty string
-        let acceptance_criteria = if let Some(ac) = &self.content().acceptance_criteria {
-            format!("\n\n## Acceptance Criteria\n\n{}", ac)
-        } else {
-            String::new()
-        };
-
         // Combine everything
         Ok(format!(
-            "---\n{}\n---\n\n{}{}",
+            "---\n{}\n---\n\n{}",
             frontmatter.trim_end(),
-            content_body,
-            acceptance_criteria
+            self.content().full_content()
         ))
     }
 }
@@ -504,11 +493,23 @@ Details on how to implement this.
         let file_path = temp_dir.path().join("test-task.md");
 
         task.to_file(&file_path).await.unwrap();
+
+        let written_content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(
+            written_content.matches("## Acceptance Criteria").count(),
+            1,
+            "acceptance criteria header must not be duplicated on save"
+        );
+
         let loaded_task = Task::from_file(&file_path).await.unwrap();
 
         assert_eq!(loaded_task.title(), task.title());
         assert_eq!(loaded_task.phase().unwrap(), task.phase().unwrap());
         assert_eq!(loaded_task.content().body, task.content().body);
+        assert_eq!(
+            loaded_task.content().acceptance_criteria,
+            task.content().acceptance_criteria
+        );
         assert_eq!(loaded_task.archived(), task.archived());
         assert_eq!(loaded_task.tags().len(), task.tags().len());
     }

--- a/crates/metis-docs-core/src/domain/documents/vision/mod.rs
+++ b/crates/metis-docs-core/src/domain/documents/vision/mod.rs
@@ -217,22 +217,11 @@ impl Vision {
             DocumentValidationError::InvalidContent(format!("Frontmatter render error: {}", e))
         })?;
 
-        // Use the actual content body
-        let content_body = &self.content().body;
-
-        // Use actual acceptance criteria if present, otherwise empty string
-        let acceptance_criteria = if let Some(ac) = &self.content().acceptance_criteria {
-            format!("\n\n## Acceptance Criteria\n\n{}", ac)
-        } else {
-            String::new()
-        };
-
         // Combine everything
         Ok(format!(
-            "---\n{}\n---\n\n{}{}",
+            "---\n{}\n---\n\n{}",
             frontmatter.trim_end(),
-            content_body,
-            acceptance_criteria
+            self.content().full_content()
         ))
     }
 }


### PR DESCRIPTION
## Summary

Editing then re-saving any Metis document (Task, Initiative, ADR, Vision, Specification) duplicated the `## Acceptance Criteria` header on disk. `DocumentContent::from_markdown` stores the parsed acceptance-criteria field *including* the header text, but each document type's serializer separately re-prepended `"## Acceptance Criteria"` before writing, doubling it up on any load-then-save cycle.

This centralizes header handling in `DocumentContent`: `from_markdown` now strips the header on parse, and `full_content()` is the single place that re-adds it. All five document types (previously each carrying their own copy of the same header-prepending logic) now just call `self.content().full_content()`. The same bug existed identically in all five, so all five are fixed rather than patching Task alone.

Added a round-trip regression test on `DocumentContent` and strengthened the existing Task save/load test to assert the header appears exactly once in the written file.